### PR TITLE
feat: Redesign settings with realistic veterinary configurations

### DIFF
--- a/.changeset/redesign-settings.md
+++ b/.changeset/redesign-settings.md
@@ -1,0 +1,11 @@
+---
+"@coongro/patients": minor
+---
+
+Redesign settings with realistic veterinary configurations
+
+- Add 7 realistic settings for veterinary clinics (Argentine market)
+- General page: default species, open detail on create, hide deceased, profile completeness
+- Registration page: required sex, birth date, and microchip fields
+- Migrate to SDK useSettings for real-time reactivity
+- Add excludeStatus filter for deceased patient filtering

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -88,297 +88,126 @@
           "order": 10
         },
         {
-          "id": "patients.campos",
+          "id": "patients.registro",
           "group": "patients",
-          "label": "Campos",
+          "label": "Registro",
           "icon": "assets/icons/campos.svg",
           "order": 20
-        },
-        {
-          "id": "patients.tabla",
-          "group": "patients",
-          "label": "Tabla",
-          "icon": "assets/icons/tabla.svg",
-          "order": 30
         }
       ],
       "sections": [
         {
-          "id": "patients.general.main",
+          "id": "patients.general.behavior",
           "page": "patients.general",
-          "label": "General",
+          "label": "Comportamiento",
           "order": 10,
           "items": [
-            {
-              "key": "patients.species.dog",
-              "type": "boolean",
-              "label": "Perro",
-              "description": "Habilitar especie Perro",
-              "default": true,
-              "tags": [
-                "patients",
-                "species",
-                "dog",
-                "perro"
-              ]
-            },
-            {
-              "key": "patients.species.cat",
-              "type": "boolean",
-              "label": "Gato",
-              "description": "Habilitar especie Gato",
-              "default": true,
-              "tags": [
-                "patients",
-                "species",
-                "cat",
-                "gato"
-              ]
-            },
-            {
-              "key": "patients.species.bird",
-              "type": "boolean",
-              "label": "Ave",
-              "description": "Habilitar especie Ave",
-              "default": false,
-              "tags": [
-                "patients",
-                "species",
-                "bird",
-                "ave"
-              ]
-            },
-            {
-              "key": "patients.species.reptile",
-              "type": "boolean",
-              "label": "Reptil",
-              "description": "Habilitar especie Reptil",
-              "default": false,
-              "tags": [
-                "patients",
-                "species",
-                "reptile",
-                "reptil"
-              ]
-            },
-            {
-              "key": "patients.species.rodent",
-              "type": "boolean",
-              "label": "Roedor",
-              "description": "Habilitar especie Roedor",
-              "default": false,
-              "tags": [
-                "patients",
-                "species",
-                "rodent",
-                "roedor"
-              ]
-            },
-            {
-              "key": "patients.species.other",
-              "type": "boolean",
-              "label": "Otro",
-              "description": "Habilitar especie Otro (exóticos, etc.)",
-              "default": true,
-              "tags": [
-                "patients",
-                "species",
-                "other",
-                "otro"
-              ]
-            },
             {
               "key": "patients.defaults.species",
               "type": "enum",
               "label": "Especie por defecto",
               "description": "Especie preseleccionada al crear un paciente",
-              "default": "dog",
+              "default": "Perro",
               "options": [
-                "dog",
-                "cat",
-                "bird",
-                "reptile",
-                "rodent",
-                "other"
+                "Perro",
+                "Gato"
               ],
               "tags": [
-                "patients",
-                "defaults",
-                "species",
+                "pacientes",
                 "especie",
-                "por",
-                "defecto"
+                "defecto",
+                "perro",
+                "gato"
               ]
             },
             {
               "key": "patients.behavior.openDetailOnCreate",
               "type": "boolean",
               "label": "Abrir ficha al crear",
-              "description": "Al crear un paciente, abrir automáticamente su ficha",
+              "description": "Al crear un paciente, abrir automáticamente su ficha de detalle",
               "default": true,
               "tags": [
-                "patients",
-                "behavior",
-                "opendetailoncreate",
+                "pacientes",
                 "abrir",
                 "ficha",
-                "crear"
+                "crear",
+                "detalle"
+              ]
+            },
+            {
+              "key": "patients.behavior.hideDeceased",
+              "type": "boolean",
+              "label": "Ocultar pacientes fallecidos",
+              "description": "Excluir pacientes fallecidos de la búsqueda y listado por defecto",
+              "default": true,
+              "tags": [
+                "pacientes",
+                "ocultar",
+                "fallecidos",
+                "muertos",
+                "busqueda"
+              ]
+            },
+            {
+              "key": "patients.behavior.showCompleteness",
+              "type": "boolean",
+              "label": "Indicador de completitud",
+              "description": "Mostrar qué porcentaje del perfil del paciente está completo",
+              "default": false,
+              "tags": [
+                "pacientes",
+                "completitud",
+                "perfil",
+                "porcentaje",
+                "completo"
               ]
             }
           ]
         },
         {
-          "id": "patients.campos.main",
-          "page": "patients.campos",
-          "label": "Campos",
+          "id": "patients.registro.required",
+          "page": "patients.registro",
+          "label": "Campos obligatorios",
           "order": 10,
           "items": [
-            {
-              "key": "patients.required.microchip",
-              "type": "boolean",
-              "label": "Microchip obligatorio",
-              "description": "Requerir número de microchip al crear paciente",
-              "default": false,
-              "tags": [
-                "patients",
-                "required",
-                "microchip",
-                "obligatorio"
-              ]
-            },
             {
               "key": "patients.required.sex",
               "type": "boolean",
               "label": "Sexo obligatorio",
-              "description": "Requerir sexo al crear paciente",
+              "description": "Requerir sexo al crear o editar un paciente",
               "default": false,
               "tags": [
-                "patients",
-                "required",
-                "sex",
+                "pacientes",
+                "obligatorio",
                 "sexo",
-                "obligatorio"
+                "requerir"
               ]
             },
             {
               "key": "patients.required.birthDate",
               "type": "boolean",
               "label": "Fecha de nacimiento obligatoria",
-              "description": "Requerir fecha de nacimiento al crear paciente",
+              "description": "Requerir fecha de nacimiento al crear o editar un paciente",
               "default": false,
               "tags": [
-                "patients",
-                "required",
-                "birthdate",
+                "pacientes",
+                "obligatorio",
                 "fecha",
                 "nacimiento",
-                "obligatoria"
-              ]
-            }
-          ]
-        },
-        {
-          "id": "patients.tabla.main",
-          "page": "patients.tabla",
-          "label": "Tabla",
-          "order": 10,
-          "items": [
-            {
-              "key": "patients.table.columns.breed",
-              "type": "boolean",
-              "label": "Raza",
-              "description": "Mostrar columna de raza",
-              "default": true,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "breed",
-                "raza"
+                "requerir"
               ]
             },
             {
-              "key": "patients.table.columns.sex",
+              "key": "patients.required.microchip",
               "type": "boolean",
-              "label": "Sexo",
-              "description": "Mostrar columna de sexo",
+              "label": "Microchip obligatorio",
+              "description": "Requerir número de microchip al crear o editar un paciente",
               "default": false,
               "tags": [
-                "patients",
-                "table",
-                "columns",
-                "sex",
-                "sexo"
-              ]
-            },
-            {
-              "key": "patients.table.columns.weight",
-              "type": "boolean",
-              "label": "Peso",
-              "description": "Mostrar columna de peso",
-              "default": false,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "weight",
-                "peso"
-              ]
-            },
-            {
-              "key": "patients.table.columns.microchip",
-              "type": "boolean",
-              "label": "Microchip",
-              "description": "Mostrar columna de microchip",
-              "default": false,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "microchip"
-              ]
-            },
-            {
-              "key": "patients.table.columns.status",
-              "type": "boolean",
-              "label": "Estado",
-              "description": "Mostrar columna de estado",
-              "default": true,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "status",
-                "estado"
-              ]
-            },
-            {
-              "key": "patients.table.columns.birthDate",
-              "type": "boolean",
-              "label": "Edad",
-              "description": "Mostrar columna de edad",
-              "default": true,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "birthdate",
-                "edad"
-              ]
-            },
-            {
-              "key": "patients.table.columns.reproductive",
-              "type": "boolean",
-              "label": "Estado reproductivo",
-              "description": "Mostrar columna de estado reproductivo",
-              "default": false,
-              "tags": [
-                "patients",
-                "table",
-                "columns",
-                "reproductive",
-                "estado",
-                "reproductivo"
+                "pacientes",
+                "obligatorio",
+                "microchip",
+                "requerir"
               ]
             }
           ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,25 +343,25 @@
       }
     },
     "node_modules/@coongro/core-logging": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/core-logging/-/c1dabe300628e76022b3c84ff70713f0e3b3006d",
-      "integrity": "sha512-XXXMz+McGNKwmW+7pAzoYZmkH9RkZux5Pz0/MxM5BY9QLvIDNmRgin66a5f0UHbiYmcmticmChlT9XGgIGHt9A==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/core-logging/-/11951e6546924a6c5d2987c81550d257d3d47a18",
+      "integrity": "sha512-EhFoukYILMchvaPm5laOKzlxsurl9zw0XNoaVjzJZK71ER0KKIxqB81wKCGkJvXQviZOxzCjbtx9gdC3vCdRew==",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@coongro/core-types": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/core-types/-/b33502bd6ea9374d4e3391ea3f59458bc3357ef7",
-      "integrity": "sha512-2RsFOIO+S4PzXAn5ZK2MWs/dN/56z9g6o2bkoqjXN+QdMPH9clfkEBz0Hh4DuHL6OYb4B2r5GAk7ltaUaF2LaQ==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/core-types/-/30df6330bd0c5ff23e0b3c02aa44a43dd2841548",
+      "integrity": "sha512-Whx/WNl/+lCs4TlZUVjFciqMBBmAmvEy1Ls7wOa4SlI76axSKsz25BGnvfd8YfpKsKuArnFse7qiLH282NdYcw==",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@coongro/database-core": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/database-core/-/c8599cb8ac37625e1e502478f6f2d2c03dbc207a",
-      "integrity": "sha512-J/l1gkOA+cLhOCFpQa4DtwsL2gBjgJFOeS6JJlVrh/d7WCE7r8SIQW0kXmut7iTOp3eEvzxuchyCnndbmm+sfw==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/database-core/-/73c07ad2f745d1dfd4b7ed149ffaffd482cdea11",
+      "integrity": "sha512-gjY/6Vzo+sPfrwuaFoVCqjKsbDwz1OSOdWfUCqIBDBLmoK9U47PRHEl2PROM/3o9zZrNV0uCvCugh1rG34sdDQ==",
       "dependencies": {
         "drizzle-orm": "^0.38.3",
         "postgres": "^3.4.4",
@@ -372,22 +372,22 @@
       }
     },
     "node_modules/@coongro/framework": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/framework/-/d69e729eb19b2d3e5f35e55eab25b21d1eaf1d80",
-      "integrity": "sha512-/si+mlMYhuPW3qKUCZt/IWdj5mQwKmhxupD1wTOEFYO9PbLodja3DUaPDTrPu0et6npKOVCbyOnhas2g799QQA==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/framework/-/9189731612d6ed873cab45510be5d4d976ce7da8",
+      "integrity": "sha512-mmYUEHTJiJD65svkY8uYrSCuYz1/jb84WGAgya35GXsFT6lI7sZ1xcLb4bhiKNaJUuKgYV6bG5VrAPgksrYdyA==",
       "dependencies": {
-        "@coongro/core-types": "0.15.1",
-        "@coongro/module-core": "0.15.1",
+        "@coongro/core-types": "0.17.0",
+        "@coongro/module-core": "0.17.0",
         "zod": "^3.24.1"
       }
     },
     "node_modules/@coongro/module-core": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/module-core/-/4ed346f467192825e389abdbed1406f3f6664924",
-      "integrity": "sha512-/A3L+9aigPQYH23BqGDa/OuA9JTEN0Kr4ikvPb4PeBDq/I2q5TpL1GJY9H0O/0suu7nAejq8hlG3uO3khj8CsQ==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/module-core/-/aa83395417cc3c7749397c64389ef39c24446527",
+      "integrity": "sha512-mhtPsbokpSswjbfGyEPyXjqOX6AgxBwar4Dwv3+WXlM36OQQ/uEYXUzM6qmQymLNk9IJghTPpom5TFVJ4whiLQ==",
       "dependencies": {
-        "@coongro/core-logging": "0.15.1",
-        "@coongro/database-core": "0.15.1",
+        "@coongro/core-logging": "0.17.0",
+        "@coongro/database-core": "0.17.0",
         "zod": "^3.24.1"
       },
       "engines": {
@@ -395,14 +395,14 @@
       }
     },
     "node_modules/@coongro/plugin-sdk": {
-      "version": "0.15.1",
-      "resolved": "https://coongro-staging.up.railway.app/@coongro/plugin-sdk/-/a7e6cae8c0d875ec25f2d5e61c45b75243de5cf3",
-      "integrity": "sha512-uItIwOpAeMUN0Mlr65EWiCViqzgRXtLt1JfErEiaLhJhXbE9m2cEwubVDh0O6bS/bbWaR0pJhrBo5+93JyUyQw==",
+      "version": "0.17.0",
+      "resolved": "https://coongro-staging.up.railway.app/@coongro/plugin-sdk/-/ac37af1cd13269185e96e8ae7e800a365afeed5b",
+      "integrity": "sha512-55g+LIRFOgZhf7HeS3/jVgEHIZa4KA5WBwX5tjxn21q/rqEEKj59IKpVL6SUQnG1YEPjg0tBSOgXsM4K7U6Erw==",
       "dependencies": {
-        "@coongro/core-types": "0.15.1",
-        "@coongro/database-core": "0.15.1",
-        "@coongro/framework": "0.15.1",
-        "@coongro/module-core": "0.15.1",
+        "@coongro/core-types": "0.17.0",
+        "@coongro/database-core": "0.17.0",
+        "@coongro/framework": "0.17.0",
+        "@coongro/module-core": "0.17.0",
         "@types/react": "^18.3.18"
       },
       "engines": {
@@ -410,21 +410,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -676,13 +676,6 @@
         "fs-extra": "^8.1.0"
       }
     },
-    "node_modules/@manypkg/find-root/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://coongro-staging.up.railway.app/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -822,25 +815,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://coongro-staging.up.railway.app/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://coongro-staging.up.railway.app/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",

--- a/src/components/PetDetail.tsx
+++ b/src/components/PetDetail.tsx
@@ -5,10 +5,12 @@
 import { ContactCard } from '@coongro/contacts';
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
+import { usePatientsSettings } from '../hooks/usePatientsSettings.js';
 import { usePet } from '../hooks/usePet.js';
 import { usePetsByOwner } from '../hooks/usePetsByOwner.js';
 import { useVetOwner } from '../hooks/useVetOwner.js';
 import type { PetDetailProps } from '../types/components.js';
+import type { Pet } from '../types/pet.js';
 import { calculateAge } from '../utils/age.js';
 import {
   formatSpecies,
@@ -24,6 +26,43 @@ import { PetCard } from './PetCard.js';
 const React = getHostReact();
 const UI = getHostUI();
 
+/** Campos del perfil con sus labels — fuente única para info y completitud */
+const PROFILE_FIELDS: Array<{ key: keyof Pet; label: string; format?: (v: unknown) => string }> = [
+  { key: 'species', label: 'Especie', format: (v) => formatSpecies(v as string) },
+  { key: 'breed', label: 'Raza' },
+  { key: 'sex', label: 'Sexo', format: (v) => formatSex(v as string) },
+  { key: 'birth_date', label: 'Edad', format: (v) => calculateAge(v as string) || '' },
+  { key: 'weight_kg', label: 'Peso', format: (v) => (v ? `${String(v)} kg` : '') },
+  { key: 'color_markings', label: 'Color/Señas' },
+  { key: 'microchip_number', label: 'Microchip' },
+  {
+    key: 'reproductive_status',
+    label: 'Estado reproductivo',
+    format: (v) => formatReproductive(v as string),
+  },
+];
+
+function getInfoFields(pet: Pet) {
+  return PROFILE_FIELDS.map((f) => ({
+    label: f.label,
+    value: f.format ? f.format(pet[f.key]) : (pet[f.key] as string | null),
+  })).filter((f) => f.value);
+}
+
+function calculateCompleteness(pet: Pet): { percentage: number; missing: string[] } {
+  const missing: string[] = [];
+  // name siempre está completo (es obligatorio), se cuenta aparte
+  const fields = [{ key: 'name' as keyof Pet, label: 'Nombre' }, ...PROFILE_FIELDS];
+  for (const f of fields) {
+    const val = pet[f.key];
+    if (val === null || val === undefined || val === '') {
+      missing.push(f.label);
+    }
+  }
+  const filled = fields.length - missing.length;
+  return { percentage: Math.round((filled / fields.length) * 100), missing };
+}
+
 export function PetDetail(props: PetDetailProps) {
   const {
     petId,
@@ -36,6 +75,7 @@ export function PetDetail(props: PetDetailProps) {
     className = '',
   } = props;
 
+  const { settings: pSettings } = usePatientsSettings();
   const { pet, loading, error, refetch } = usePet(petId);
   const { vetOwner } = useVetOwner(pet?.owner_id);
   const { pets: siblingPets } = usePetsByOwner(pet?.owner_id);
@@ -81,16 +121,7 @@ export function PetDetail(props: PetDetailProps) {
     (pet.allergies && pet.allergies.length > 0) ||
     (pet.chronic_conditions && pet.chronic_conditions.length > 0);
 
-  const infoFields = [
-    { label: 'Especie', value: formatSpecies(pet.species) },
-    { label: 'Raza', value: pet.breed },
-    { label: 'Sexo', value: formatSex(pet.sex) },
-    { label: 'Edad', value: age },
-    { label: 'Peso', value: pet.weight_kg ? `${pet.weight_kg} kg` : null },
-    { label: 'Color/Señas', value: pet.color_markings },
-    { label: 'Microchip', value: pet.microchip_number },
-    { label: 'Estado reproductivo', value: formatReproductive(pet.reproductive_status) },
-  ].filter((f) => f.value);
+  const infoFields = getInfoFields(pet);
 
   const sortedSections = [...extraSections].sort((a, b) => (a.order ?? 50) - (b.order ?? 50));
 
@@ -192,6 +223,49 @@ export function PetDetail(props: PetDetailProps) {
         )
       )
     ),
+
+    // Indicador de completitud
+    pSettings.showCompleteness &&
+      (() => {
+        const { percentage, missing } = calculateCompleteness(pet);
+        if (percentage >= 100) return null;
+        return React.createElement(
+          UI.Card,
+          { className: 'p-4 flex items-center gap-4' },
+          React.createElement(
+            'div',
+            { className: 'flex-1 flex flex-col gap-1' },
+            React.createElement(
+              'div',
+              { className: 'flex items-center justify-between' },
+              React.createElement(
+                'span',
+                { className: 'text-sm font-medium text-cg-text' },
+                'Completitud del perfil'
+              ),
+              React.createElement(
+                'span',
+                { className: 'text-sm text-cg-text-muted' },
+                `${percentage}%`
+              )
+            ),
+            React.createElement(
+              'div',
+              { className: 'w-full bg-cg-bg-secondary rounded-full h-2' },
+              React.createElement('div', {
+                className: 'bg-cg-accent rounded-full h-2 transition-all',
+                style: { width: `${percentage}%` },
+              })
+            ),
+            missing.length > 0 &&
+              React.createElement(
+                'span',
+                { className: 'text-xs text-cg-text-muted' },
+                `Faltan: ${missing.join(', ')}`
+              )
+          )
+        );
+      })(),
 
     // Alertas médicas
     hasAlerts &&

--- a/src/components/PetForm.tsx
+++ b/src/components/PetForm.tsx
@@ -37,11 +37,7 @@ export function PetForm(props: PetFormProps) {
   const { settings: pSettings } = usePatientsSettings();
   const { submit, isSaving } = usePetFormSubmit({ petId, settings: pSettings, onSuccess });
 
-  // Opciones de especie filtradas según settings
-  const speciesOptions = pSettings.enabledSpecies.map((code) => ({
-    label: SPECIES_LABELS[code] ?? code,
-    value: code,
-  }));
+  const speciesOptions = toSelectOptions(SPECIES_LABELS);
 
   const [formData, setFormData] = useState<Record<string, unknown>>({
     species: pSettings.defaultSpecies,
@@ -60,6 +56,19 @@ export function PetForm(props: PetFormProps) {
   // Modal para crear contacto desde el picker
   const [showCreateContact, setShowCreateContact] = useState(false);
   const [createContactName, setCreateContactName] = useState('');
+
+  // Sincronizar especie por defecto cuando los settings cargan (solo en creación)
+  useEffect(() => {
+    if (!isEdit && pSettings.defaultSpecies) {
+      setFormData((prev) => ({
+        ...prev,
+        species:
+          prev.species === 'dog' || prev.species === 'cat'
+            ? pSettings.defaultSpecies
+            : prev.species,
+      }));
+    }
+  }, [isEdit, pSettings.defaultSpecies]);
 
   useEffect(() => {
     if (isEdit && pet) {

--- a/src/components/PetForm.tsx
+++ b/src/components/PetForm.tsx
@@ -21,7 +21,7 @@ import {
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useEffect, useCallback } = React;
+const { useState, useEffect, useCallback, useRef } = React;
 
 const FIELD_CLASS = 'flex flex-col gap-1.5';
 const SEX_OPTIONS = toSelectOptions(SEX_LABELS);
@@ -53,19 +53,19 @@ export function PetForm(props: PetFormProps) {
   const [allergyInput, setAllergyInput] = useState('');
   const [chronicInput, setChronicInput] = useState('');
 
+  // Controla si el usuario ya cambió la especie manualmente
+  const userChangedSpecies = useRef(false);
+
   // Modal para crear contacto desde el picker
   const [showCreateContact, setShowCreateContact] = useState(false);
   const [createContactName, setCreateContactName] = useState('');
 
-  // Sincronizar especie por defecto cuando los settings cargan (solo en creación)
+  // Sincronizar especie por defecto cuando los settings cargan (solo en creación, si el usuario no cambió)
   useEffect(() => {
-    if (!isEdit && pSettings.defaultSpecies) {
+    if (!isEdit && pSettings.defaultSpecies && !userChangedSpecies.current) {
       setFormData((prev) => ({
         ...prev,
-        species:
-          prev.species === 'dog' || prev.species === 'cat'
-            ? pSettings.defaultSpecies
-            : prev.species,
+        species: pSettings.defaultSpecies,
       }));
     }
   }, [isEdit, pSettings.defaultSpecies]);
@@ -181,7 +181,17 @@ export function PetForm(props: PetFormProps) {
       renderSection(
         'Datos de la mascota',
         renderField('Nombre', 'name', 'text', formData, handleChange, true, 'Nombre de la mascota'),
-        renderSelect('Especie', 'species', speciesOptions, formData, handleChange, true),
+        renderSelect(
+          'Especie',
+          'species',
+          speciesOptions,
+          formData,
+          (key, value) => {
+            userChangedSpecies.current = true;
+            handleChange(key, value);
+          },
+          true
+        ),
         renderField('Raza', 'breed', 'text', formData, handleChange, false, 'Raza'),
         renderSelect('Sexo', 'sex', SEX_OPTIONS, formData, handleChange, pSettings.requireSex),
         renderField(

--- a/src/components/PetsTable.tsx
+++ b/src/components/PetsTable.tsx
@@ -16,11 +16,12 @@ import {
   formatSex,
   formatReproductive,
   SPECIES_EMOJI,
+  SPECIES_LABELS,
 } from '../utils/labels.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback, useMemo } = React;
+const { useState, useCallback, useMemo, useEffect } = React;
 
 type ColumnDef = {
   key: string;
@@ -96,7 +97,11 @@ export function PetsTable(props: PetsTableProps) {
     prevPage,
     goToPage,
     refetch,
-  } = usePets({ ...initialFilters, pageSize });
+  } = usePets({
+    ...initialFilters,
+    excludeStatus: pSettings.hideDeceased ? 'deceased' : undefined,
+    pageSize,
+  });
 
   const [searchValue, setSearchValue] = useState('');
   const [activeSpeciesFilter, setActiveSpeciesFilter] = useState<string>(
@@ -108,25 +113,25 @@ export function PetsTable(props: PetsTableProps) {
   const [sortKey, setSortKey] = useState<string>('');
   const [sortDir, setSortDir] = useState<SortDirection>('asc');
 
+  // Re-aplicar filtros cuando hideDeceased cambia en tiempo real
+  useEffect(() => {
+    setFilters({
+      query: searchValue || undefined,
+      species: activeSpeciesFilter || undefined,
+      status: activeStatusFilter || undefined,
+      excludeStatus: !activeStatusFilter && pSettings.hideDeceased ? 'deceased' : undefined,
+    });
+  }, [pSettings.hideDeceased]);
+
   const hasActiveFilters =
     searchValue !== '' || activeSpeciesFilter !== '' || activeStatusFilter !== '';
 
-  // Filtrar columnas según settings de visibilidad
-  const defaultColumns = useMemo(
-    () => ALL_COLUMNS.filter((col) => pSettings.visibleColumns.has(col.key)),
-    [pSettings.visibleColumns]
-  );
-
   const allColumns = useMemo(
-    () => [...(columns ?? defaultColumns), ...extraColumns],
-    [columns, defaultColumns, extraColumns]
+    () => [...(columns ?? ALL_COLUMNS), ...extraColumns],
+    [columns, extraColumns]
   );
 
-  // Especies habilitadas para los botones de filtro
-  const speciesFilterOptions = useMemo(
-    () => ['', ...pSettings.enabledSpecies],
-    [pSettings.enabledSpecies]
-  );
+  const speciesFilterOptions = useMemo(() => ['', ...Object.keys(SPECIES_LABELS)], []);
 
   // Centraliza la actualización de filtros evitando duplicación
   const applyFilters = useCallback(
@@ -140,9 +145,11 @@ export function PetsTable(props: PetsTableProps) {
         query: merged.query || undefined,
         species: merged.species || undefined,
         status: merged.status || undefined,
+        // Si no hay filtro de estado explícito y hideDeceased está activo, excluir fallecidos
+        excludeStatus: !merged.status && pSettings.hideDeceased ? 'deceased' : undefined,
       });
     },
-    [setFilters, searchValue, activeSpeciesFilter, activeStatusFilter]
+    [setFilters, searchValue, activeSpeciesFilter, activeStatusFilter, pSettings.hideDeceased]
   );
 
   const handleSearch = useCallback(

--- a/src/hooks/usePatientsSettings.ts
+++ b/src/hooks/usePatientsSettings.ts
@@ -1,121 +1,55 @@
 /**
  * Hook para cargar las configuraciones del plugin de pacientes.
- * Usa settings.getAll('patients.') para traer todo de una vez.
+ * Usa useSettings del SDK para reactividad automática.
  */
-import { getHostReact, settings } from '@coongro/plugin-sdk';
-
-const React = getHostReact();
-const { useState, useEffect } = React;
+import { useSettings } from '@coongro/plugin-sdk';
 
 export interface PatientsSettings {
-  // Especies habilitadas
-  enabledSpecies: string[];
+  // Comportamiento
   defaultSpecies: string;
+  openDetailOnCreate: boolean;
+  hideDeceased: boolean;
+  showCompleteness: boolean;
 
   // Campos obligatorios
-  requireMicrochip: boolean;
   requireSex: boolean;
   requireBirthDate: boolean;
-
-  // Columnas visibles en la tabla
-  visibleColumns: Set<string>;
-
-  // Comportamiento
-  openDetailOnCreate: boolean;
+  requireMicrochip: boolean;
 }
 
-const SPECIES_KEYS: Record<string, string> = {
-  'patients.species.dog': 'dog',
-  'patients.species.cat': 'cat',
-  'patients.species.bird': 'bird',
-  'patients.species.reptile': 'reptile',
-  'patients.species.rodent': 'rodent',
-  'patients.species.other': 'other',
-};
-
-const COLUMN_KEYS: Record<string, string> = {
-  'patients.table.columns.breed': 'breed',
-  'patients.table.columns.sex': 'sex',
-  'patients.table.columns.weight': 'weight_kg',
-  'patients.table.columns.microchip': 'microchip_number',
-  'patients.table.columns.status': 'status',
-  'patients.table.columns.birthDate': 'birth_date',
-  'patients.table.columns.reproductive': 'reproductive_status',
+// Mapeo temporal: label español → código interno (workaround hasta Coongro/Coongro#314)
+const SPECIES_LABEL_TO_CODE: Record<string, string> = {
+  Perro: 'dog',
+  Gato: 'cat',
 };
 
 /** Defaults cuando no hay settings guardados (mismos que el manifest) */
 const DEFAULTS: Record<string, unknown> = {
-  'patients.species.dog': true,
-  'patients.species.cat': true,
-  'patients.species.bird': false,
-  'patients.species.reptile': false,
-  'patients.species.rodent': false,
-  'patients.species.other': true,
-  'patients.defaults.species': 'dog',
-  'patients.required.microchip': false,
+  'patients.defaults.species': 'Perro',
+  'patients.behavior.openDetailOnCreate': true,
+  'patients.behavior.hideDeceased': true,
+  'patients.behavior.showCompleteness': false,
   'patients.required.sex': false,
   'patients.required.birthDate': false,
-  'patients.table.columns.breed': true,
-  'patients.table.columns.sex': false,
-  'patients.table.columns.weight': false,
-  'patients.table.columns.microchip': false,
-  'patients.table.columns.status': true,
-  'patients.table.columns.birthDate': true,
-  'patients.table.columns.reproductive': false,
-  'patients.behavior.openDetailOnCreate': true,
+  'patients.required.microchip': false,
 };
 
 function parseSettings(raw: Record<string, unknown>): PatientsSettings {
   const get = (key: string) => raw[key] ?? DEFAULTS[key];
 
-  // Especies habilitadas
-  const enabledSpecies: string[] = [];
-  for (const [settingKey, speciesCode] of Object.entries(SPECIES_KEYS)) {
-    if (get(settingKey)) enabledSpecies.push(speciesCode);
-  }
-
-  // Columnas visibles (name y species siempre visibles)
-  const visibleColumns = new Set<string>(['name', 'species']);
-  for (const [settingKey, colKey] of Object.entries(COLUMN_KEYS)) {
-    if (get(settingKey)) visibleColumns.add(colKey);
-  }
-
   return {
-    enabledSpecies,
-    defaultSpecies: (get('patients.defaults.species') as string) || 'dog',
-    requireMicrochip: get('patients.required.microchip') as boolean,
+    defaultSpecies: SPECIES_LABEL_TO_CODE[get('patients.defaults.species') as string] ?? 'dog',
+    openDetailOnCreate: get('patients.behavior.openDetailOnCreate') as boolean,
+    hideDeceased: get('patients.behavior.hideDeceased') as boolean,
+    showCompleteness: get('patients.behavior.showCompleteness') as boolean,
     requireSex: get('patients.required.sex') as boolean,
     requireBirthDate: get('patients.required.birthDate') as boolean,
-    visibleColumns,
-    openDetailOnCreate: get('patients.behavior.openDetailOnCreate') as boolean,
+    requireMicrochip: get('patients.required.microchip') as boolean,
   };
 }
 
-/** Settings parseados por defecto (antes de cargar desde la API) */
-const DEFAULT_SETTINGS = parseSettings({});
-
 export function usePatientsSettings() {
-  const [data, setData] = useState<PatientsSettings>(DEFAULT_SETTINGS);
-  const [loading, setLoading] = useState(true);
+  const { values, loading } = useSettings('patients.');
 
-  useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      try {
-        const raw = await settings.getAll('patients.');
-        if (!cancelled) setData(parseSettings(raw));
-      } catch {
-        // Si falla, usar defaults
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return { settings: data, loading };
+  return { settings: parseSettings(values), loading };
 }

--- a/src/hooks/usePatientsSettings.ts
+++ b/src/hooks/usePatientsSettings.ts
@@ -23,6 +23,14 @@ const SPECIES_LABEL_TO_CODE: Record<string, string> = {
   Gato: 'cat',
 };
 
+/** Convierte valor desconocido a boolean (soporta string "true"/"false" de la API) */
+function toBool(val: unknown, fallback: boolean): boolean {
+  if (typeof val === 'boolean') return val;
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  return fallback;
+}
+
 /** Defaults cuando no hay settings guardados (mismos que el manifest) */
 const DEFAULTS: Record<string, unknown> = {
   'patients.defaults.species': 'Perro',
@@ -38,13 +46,13 @@ function parseSettings(raw: Record<string, unknown>): PatientsSettings {
   const get = (key: string) => raw[key] ?? DEFAULTS[key];
 
   return {
-    defaultSpecies: SPECIES_LABEL_TO_CODE[get('patients.defaults.species') as string] ?? 'dog',
-    openDetailOnCreate: get('patients.behavior.openDetailOnCreate') as boolean,
-    hideDeceased: get('patients.behavior.hideDeceased') as boolean,
-    showCompleteness: get('patients.behavior.showCompleteness') as boolean,
-    requireSex: get('patients.required.sex') as boolean,
-    requireBirthDate: get('patients.required.birthDate') as boolean,
-    requireMicrochip: get('patients.required.microchip') as boolean,
+    defaultSpecies: SPECIES_LABEL_TO_CODE[String(get('patients.defaults.species'))] ?? 'dog',
+    openDetailOnCreate: toBool(get('patients.behavior.openDetailOnCreate'), true),
+    hideDeceased: toBool(get('patients.behavior.hideDeceased'), true),
+    showCompleteness: toBool(get('patients.behavior.showCompleteness'), false),
+    requireSex: toBool(get('patients.required.sex'), false),
+    requireBirthDate: toBool(get('patients.required.birthDate'), false),
+    requireMicrochip: toBool(get('patients.required.microchip'), false),
   };
 }
 

--- a/src/hooks/usePetFormSubmit.ts
+++ b/src/hooks/usePetFormSubmit.ts
@@ -123,8 +123,14 @@ export function usePetFormSubmit(options: UsePetFormSubmitOptions) {
           }
         }
         onSuccess?.(result);
-      } catch {
-        toast.error('Error', 'Ocurrió un error inesperado al guardar el paciente.');
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[usePetFormSubmit] Submit failed:', err);
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Ocurrió un error inesperado al guardar el paciente.';
+        toast.error('Error al guardar', message);
       }
     },
     [settings, isEdit, petId, create, update, ensureOwner, onSuccess, toast]

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
 // NO exportar aquí: contienen imports de drizzle-orm que no corren en el browser
 export type { PetRow, NewPetRow } from './schema/pet.js';
 export type { VetOwnerRow, NewVetOwnerRow } from './schema/vet-owner.js';
-export type { PetSearchParams, CountResult } from './repositories/pet.repository.js';
+export type { CountResult } from './repositories/pet.repository.js';
 export type { VetOwnerSearchParams } from './repositories/vet-owner.repository.js';
 
 // Types

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -2,6 +2,6 @@
  * Repository exports
  */
 export { PetRepository } from './pet.repository.js';
-export type { PetSearchParams, CountResult } from './pet.repository.js';
+export type { CountResult } from './pet.repository.js';
 export { VetOwnerRepository } from './vet-owner.repository.js';
 export type { VetOwnerSearchParams } from './vet-owner.repository.js';

--- a/src/repositories/pet.repository.ts
+++ b/src/repositories/pet.repository.ts
@@ -4,22 +4,7 @@ import { eq, and, or, ne, ilike, isNull, sql, asc, desc } from 'drizzle-orm';
 
 import { petTable } from '../schema/pet.js';
 import type { PetRow, NewPetRow } from '../schema/pet.js';
-
-export interface PetSearchParams {
-  query?: string;
-  species?: string;
-  status?: string;
-  excludeStatus?: string;
-  breed?: string;
-  ownerId?: string;
-  tags?: string[];
-  isActive?: boolean;
-  includeDeleted?: boolean;
-  limit?: number;
-  offset?: number;
-  orderBy?: string;
-  orderDir?: 'asc' | 'desc';
-}
+import type { PetFilters } from '../types/filters.js';
 
 export interface CountResult {
   label: string;
@@ -107,7 +92,7 @@ export class PetRepository {
     offset,
     orderBy: orderByField,
     orderDir = 'asc',
-  }: PetSearchParams): Promise<PetRow[]> {
+  }: PetFilters): Promise<PetRow[]> {
     return this.db.ormQuery((tx) => {
       const conditions: SQL[] = [];
 

--- a/src/repositories/pet.repository.ts
+++ b/src/repositories/pet.repository.ts
@@ -1,6 +1,6 @@
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import type { SQL } from 'drizzle-orm';
-import { eq, and, or, ilike, isNull, sql, asc, desc } from 'drizzle-orm';
+import { eq, and, or, ne, ilike, isNull, sql, asc, desc } from 'drizzle-orm';
 
 import { petTable } from '../schema/pet.js';
 import type { PetRow, NewPetRow } from '../schema/pet.js';
@@ -9,6 +9,7 @@ export interface PetSearchParams {
   query?: string;
   species?: string;
   status?: string;
+  excludeStatus?: string;
   breed?: string;
   ownerId?: string;
   tags?: string[];
@@ -96,6 +97,7 @@ export class PetRepository {
     query,
     species,
     status,
+    excludeStatus,
     breed,
     ownerId,
     tags,
@@ -131,6 +133,8 @@ export class PetRepository {
 
       if (status) {
         conditions.push(eq(petTable.status, status));
+      } else if (excludeStatus) {
+        conditions.push(ne(petTable.status, excludeStatus));
       }
 
       if (breed) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,6 @@ export type { PetRow, NewPetRow } from './schema/pet.js';
 export { vetOwnerTable } from './schema/vet-owner.js';
 export type { VetOwnerRow, NewVetOwnerRow } from './schema/vet-owner.js';
 export { PetRepository } from './repositories/pet.repository.js';
-export type { PetSearchParams, CountResult } from './repositories/pet.repository.js';
+export type { CountResult } from './repositories/pet.repository.js';
 export { VetOwnerRepository } from './repositories/vet-owner.repository.js';
 export type { VetOwnerSearchParams } from './repositories/vet-owner.repository.js';

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -7,6 +7,7 @@ export interface PetFilters {
   query?: string;
   species?: string;
   status?: string;
+  excludeStatus?: string;
   breed?: string;
   ownerId?: string;
   tags?: string[];

--- a/src/views/patients-list/index.tsx
+++ b/src/views/patients-list/index.tsx
@@ -6,6 +6,7 @@ import { getHostReact, usePlugin } from '@coongro/plugin-sdk';
 import { CreatePetButton } from '../../components/CreatePetButton.js';
 import { PetsTable } from '../../components/PetsTable.js';
 import { PetStats } from '../../components/PetStats.js';
+import { usePatientsSettings } from '../../hooks/usePatientsSettings.js';
 import type { Pet } from '../../types/pet.js';
 
 const React = getHostReact();
@@ -13,6 +14,7 @@ const { useCallback } = React;
 
 export function PatientsListView() {
   const { views } = usePlugin();
+  const { settings: pSettings } = usePatientsSettings();
 
   const handleRowClick = useCallback(
     (pet: Pet) => {
@@ -23,9 +25,11 @@ export function PatientsListView() {
 
   const handleCreated = useCallback(
     (pet: Pet) => {
-      views.open('patients.detail.open', { petId: pet.id });
+      if (pSettings.openDetailOnCreate) {
+        views.open('patients.detail.open', { petId: pet.id });
+      }
     },
-    [views]
+    [views, pSettings.openDetailOnCreate]
   );
 
   return (


### PR DESCRIPTION
Closes #13

## Changes
- Replace test settings with 7 realistic settings based on real veterinary clinic needs (Argentine market)
- **General page**: default species, open detail on create, hide deceased patients, profile completeness indicator
- **Registration page**: required sex, birth date, and microchip fields
- Migrate `usePatientsSettings` hook to SDK `useSettings` for real-time reactivity
- Add `excludeStatus` filter to pet repository for deceased patient filtering
- Extract shared `PROFILE_FIELDS` constant for info display and completeness calculation
- Sync default species on async settings load in PetForm

## Testing
- [x] Default species: changes between Perro/Gato reflected in new patient form
- [x] Open detail on create: toggle controls navigation after patient creation
- [x] Hide deceased: filters deceased patients from list, accessible via status filter
- [x] Completeness indicator: shows progress bar with missing fields in patient detail
- [x] Required fields: sex, birth date, microchip block save when enabled
- [x] Settings react in real-time without page reload (via SDK useSettings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)