### PR TITLE
Promote develop to staging

### DIFF
--- a/.changeset/restore-species-settings.md
+++ b/.changeset/restore-species-settings.md
@@ -1,0 +1,10 @@
+---
+"@coongro/patients": patch
+---
+
+Restore full species toggles and options in settings
+
+- Restore 6 individual species toggles (dog, cat, bird, reptile, rodent, other) in manifest
+- Restore all 6 options in default species enum (was reduced to only dog/cat)
+- Update usePatientsSettings to expose enabledSpecies map
+- Filter species options in PetForm and PetsTable by enabled species

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -97,6 +97,62 @@
       ],
       "sections": [
         {
+          "id": "patients.general.species",
+          "page": "patients.general",
+          "label": "Especies habilitadas",
+          "order": 5,
+          "items": [
+            {
+              "key": "patients.species.dog",
+              "type": "boolean",
+              "label": "Perro",
+              "description": "Habilitar especie Perro",
+              "default": true,
+              "tags": ["pacientes", "especie", "perro"]
+            },
+            {
+              "key": "patients.species.cat",
+              "type": "boolean",
+              "label": "Gato",
+              "description": "Habilitar especie Gato",
+              "default": true,
+              "tags": ["pacientes", "especie", "gato"]
+            },
+            {
+              "key": "patients.species.bird",
+              "type": "boolean",
+              "label": "Ave",
+              "description": "Habilitar especie Ave",
+              "default": false,
+              "tags": ["pacientes", "especie", "ave"]
+            },
+            {
+              "key": "patients.species.reptile",
+              "type": "boolean",
+              "label": "Reptil",
+              "description": "Habilitar especie Reptil",
+              "default": false,
+              "tags": ["pacientes", "especie", "reptil"]
+            },
+            {
+              "key": "patients.species.rodent",
+              "type": "boolean",
+              "label": "Roedor",
+              "description": "Habilitar especie Roedor",
+              "default": false,
+              "tags": ["pacientes", "especie", "roedor"]
+            },
+            {
+              "key": "patients.species.other",
+              "type": "boolean",
+              "label": "Otro",
+              "description": "Habilitar especie Otro (exóticos, etc.)",
+              "default": true,
+              "tags": ["pacientes", "especie", "otro", "exótico"]
+            }
+          ]
+        },
+        {
           "id": "patients.general.behavior",
           "page": "patients.general",
           "label": "Comportamiento",
@@ -110,14 +166,16 @@
               "default": "Perro",
               "options": [
                 "Perro",
-                "Gato"
+                "Gato",
+                "Ave",
+                "Reptil",
+                "Roedor",
+                "Otro"
               ],
               "tags": [
                 "pacientes",
                 "especie",
-                "defecto",
-                "perro",
-                "gato"
+                "defecto"
               ]
             },
             {

--- a/src/components/PetForm.tsx
+++ b/src/components/PetForm.tsx
@@ -65,7 +65,9 @@ export function PetForm(props: PetFormProps) {
   const { settings: pSettings } = usePatientsSettings();
   const { submit, isSaving } = usePetFormSubmit({ petId, settings: pSettings, onSuccess });
 
-  const speciesOptions = toSelectOptions(SPECIES_LABELS);
+  const speciesOptions = toSelectOptions(SPECIES_LABELS).filter(
+    (opt) => pSettings.enabledSpecies[opt.value] !== false
+  );
 
   const [formData, setFormData] = useState<Record<string, unknown>>({
     species: pSettings.defaultSpecies,

--- a/src/components/PetsTable.tsx
+++ b/src/components/PetsTable.tsx
@@ -134,7 +134,13 @@ export function PetsTable(props: PetsTableProps) {
     [columns, extraColumns]
   );
 
-  const speciesFilterOptions = useMemo(() => ['', ...Object.keys(SPECIES_LABELS)], []);
+  const speciesFilterOptions = useMemo(
+    () => [
+      '',
+      ...Object.keys(SPECIES_LABELS).filter((sp) => pSettings.enabledSpecies[sp] !== false),
+    ],
+    [pSettings.enabledSpecies]
+  );
 
   // Centraliza la actualización de filtros evitando duplicación
   const applyFilters = useCallback(

--- a/src/hooks/usePatientsSettings.ts
+++ b/src/hooks/usePatientsSettings.ts
@@ -5,6 +5,9 @@
 import { useSettings } from '@coongro/plugin-sdk';
 
 export interface PatientsSettings {
+  // Especies habilitadas
+  enabledSpecies: Record<string, boolean>;
+
   // Comportamiento
   defaultSpecies: string;
   openDetailOnCreate: boolean;
@@ -17,11 +20,18 @@ export interface PatientsSettings {
   requireMicrochip: boolean;
 }
 
-// Mapeo temporal: label español → código interno (workaround hasta Coongro/Coongro#314)
+/** Mapeo label español → código interno */
 const SPECIES_LABEL_TO_CODE: Record<string, string> = {
   Perro: 'dog',
   Gato: 'cat',
+  Ave: 'bird',
+  Reptil: 'reptile',
+  Roedor: 'rodent',
+  Otro: 'other',
 };
+
+/** Especies disponibles y sus keys en settings */
+const SPECIES_KEYS = ['dog', 'cat', 'bird', 'reptile', 'rodent', 'other'] as const;
 
 /** Convierte valor desconocido a boolean (soporta string "true"/"false" de la API) */
 function toBool(val: unknown, fallback: boolean): boolean {
@@ -33,6 +43,12 @@ function toBool(val: unknown, fallback: boolean): boolean {
 
 /** Defaults cuando no hay settings guardados (mismos que el manifest) */
 const DEFAULTS: Record<string, unknown> = {
+  'patients.species.dog': true,
+  'patients.species.cat': true,
+  'patients.species.bird': false,
+  'patients.species.reptile': false,
+  'patients.species.rodent': false,
+  'patients.species.other': true,
   'patients.defaults.species': 'Perro',
   'patients.behavior.openDetailOnCreate': true,
   'patients.behavior.hideDeceased': true,
@@ -45,7 +61,16 @@ const DEFAULTS: Record<string, unknown> = {
 function parseSettings(raw: Record<string, unknown>): PatientsSettings {
   const get = (key: string) => raw[key] ?? DEFAULTS[key];
 
+  const enabledSpecies: Record<string, boolean> = {};
+  for (const sp of SPECIES_KEYS) {
+    enabledSpecies[sp] = toBool(
+      get(`patients.species.${sp}`),
+      DEFAULTS[`patients.species.${sp}`] as boolean
+    );
+  }
+
   return {
+    enabledSpecies,
     defaultSpecies: SPECIES_LABEL_TO_CODE[String(get('patients.defaults.species'))] ?? 'dog',
     openDetailOnCreate: toBool(get('patients.behavior.openDetailOnCreate'), true),
     hideDeceased: toBool(get('patients.behavior.hideDeceased'), true),


### PR DESCRIPTION
## Summary
- fix: Restore full species toggles and options in settings (#34)

Promotes develop to staging for auto-versioning.