### PR TITLE
fix: Add Lucide icons to species enum in settings

### DIFF
--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -165,12 +165,12 @@
               "description": "Especie preseleccionada al crear un paciente",
               "default": "Perro",
               "options": [
-                "Perro",
-                "Gato",
-                "Ave",
-                "Reptil",
-                "Roedor",
-                "Otro"
+                { "value": "Perro", "icon": "Dog" },
+                { "value": "Gato", "icon": "Cat" },
+                { "value": "Ave", "icon": "Bird" },
+                { "value": "Reptil", "icon": "Turtle" },
+                { "value": "Roedor", "icon": "Rabbit" },
+                { "value": "Otro", "icon": "PawPrint" }
               ],
               "tags": [
                 "pacientes",


### PR DESCRIPTION
Relates to #33

## Changes
- Use `{ value, icon }` format for species enum options in manifest
- Settings dropdown now shows Lucide icons (Dog, Cat, Bird, Turtle, Rabbit, PawPrint) next to species names

## Testing
- [x] Verified species dropdown in "Registrar Paciente" form shows icons
- [x] Verified only enabled species appear in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)