### PR TITLE
feat: Use DatePicker from @coongro/calendar for birth date

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@coongro/calendar": ">=0.1.0",
     "@coongro/contacts": ">=1.0.0"
   },
   "peerDependencies": {

--- a/src/components/PetForm.tsx
+++ b/src/components/PetForm.tsx
@@ -2,6 +2,7 @@
  * Formulario de crear/editar mascota.
  * Incluye ContactPicker de @coongro/contacts para seleccionar dueño.
  */
+import { DatePicker } from '@coongro/calendar';
 import { ContactPicker, ContactForm } from '@coongro/contacts';
 import type { Contact } from '@coongro/contacts';
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
@@ -274,14 +275,16 @@ export function PetForm(props: PetFormProps) {
             )
           )
         ),
-        renderField(
-          'Fecha nacimiento',
-          'birth_date',
-          'date',
-          formData,
-          handleChange,
-          pSettings.requireBirthDate,
-          ''
+        React.createElement(
+          'div',
+          { className: FIELD_CLASS },
+          renderLabel('Fecha nacimiento', pSettings.requireBirthDate),
+          React.createElement(DatePicker, {
+            value: (formData.birth_date as string) ?? '',
+            onChange: (date: string) => handleChange('birth_date', date),
+            maxDate: new Date().toISOString().slice(0, 10),
+            placeholder: 'Seleccionar fecha',
+          })
         ),
         renderField(
           'Color/Señas',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,9 @@
       "@coongro/plugin-sdk/*": [
         "../../packages/plugin-sdk/dist/*"
       ],
+      "@coongro/calendar": [
+        "../calendar/dist/index.d.ts"
+      ],
       "@coongro/contacts": [
         "../contacts/dist/index.d.ts"
       ],


### PR DESCRIPTION
## Summary
- Replace native `<input type="date">` with `DatePicker` component from `@coongro/calendar` for the birth date field in PetForm
- Add `@coongro/calendar` as dependency + tsconfig path mapping
- `maxDate` set to today to prevent future dates

## Dependencies
- Requires Coongro/calendar#17 merged first (`DatePicker` export + inline styles fix)

## Test plan
- [ ] Open "Nuevo paciente" form → verify DatePicker renders as calendar popover
- [ ] Select a birth date → verify it saves correctly
- [ ] Edit existing patient → verify birth date loads correctly in DatePicker
- [ ] Verify future dates are disabled

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)