### PR TITLE
feat: migrate preferred_vet to StaffPicker

### DIFF
--- a/.changeset/migrate-preferred-vet-staff-picker.md
+++ b/.changeset/migrate-preferred-vet-staff-picker.md
@@ -1,0 +1,5 @@
+---
+'@coongro/patients': minor
+---
+
+Migrate `preferred_vet` (free text) to `preferred_vet_staff_id` with `StaffPicker` + `StaffBadge` from `@coongro/staff`, consistent with consultations `vet_name → staff_id` migration.

--- a/drizzle/0001_migrate_preferred_vet_to_staff_id.sql
+++ b/drizzle/0001_migrate_preferred_vet_to_staff_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "module_patients_vet_owners" DROP COLUMN IF EXISTS "preferred_vet";--> statement-breakpoint
+ALTER TABLE "module_patients_vet_owners" ADD COLUMN "preferred_vet_staff_id" text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,229 @@
+{
+  "id": "07b0da7e-b06e-4527-a35d-4bb5813d94b2",
+  "prevId": "418866b6-e070-4abd-b5d0-e463dcac0731",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.module_patients_pets": {
+      "name": "module_patients_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_markings": {
+          "name": "color_markings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reproductive_status": {
+          "name": "reproductive_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergies": {
+          "name": "allergies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chronic_conditions": {
+          "name": "chronic_conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_patients_vet_owners": {
+      "name": "module_patients_vet_owners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_source": {
+          "name": "referral_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preferred_vet_staff_id": {
+          "name": "preferred_vet_staff_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771223475423,
       "tag": "0000_natural_kabuki",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0001_migrate_preferred_vet_to_staff_id",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "dependencies": {
     "@coongro/calendar": ">=0.1.0",
-    "@coongro/contacts": ">=1.0.0"
+    "@coongro/contacts": ">=1.0.0",
+    "@coongro/staff": ">=0.1.0"
   },
   "peerDependencies": {
     "@coongro/plugin-sdk": ">=0.14.0"

--- a/src/components/PetDetail.tsx
+++ b/src/components/PetDetail.tsx
@@ -4,6 +4,7 @@
  */
 import { ContactCard } from '@coongro/contacts';
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+import { StaffBadge } from '@coongro/staff';
 
 import { usePatientsSettings } from '../hooks/usePatientsSettings.js';
 import { usePet } from '../hooks/usePet.js';
@@ -345,11 +346,15 @@ export function PetDetail(props: PetDetailProps) {
                   { className: 'text-cg-text' },
                   `Emergencia: ${vetOwner.emergency_phone}`
                 ),
-              vetOwner.preferred_vet &&
+              vetOwner.preferred_vet_staff_id &&
                 React.createElement(
-                  'span',
-                  { className: 'text-cg-text' },
-                  `Vet preferido: ${vetOwner.preferred_vet}`
+                  'div',
+                  { className: 'flex items-center gap-2 text-cg-text' },
+                  React.createElement('span', null, 'Vet preferido:'),
+                  React.createElement(StaffBadge, {
+                    staffId: vetOwner.preferred_vet_staff_id,
+                    variant: 'compact',
+                  })
                 ),
               vetOwner.referral_source &&
                 React.createElement(

--- a/src/components/PetForm.tsx
+++ b/src/components/PetForm.tsx
@@ -6,6 +6,8 @@ import { DatePicker } from '@coongro/calendar';
 import { ContactPicker, ContactForm } from '@coongro/contacts';
 import type { Contact } from '@coongro/contacts';
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+import { StaffPicker } from '@coongro/staff';
+import type { StaffMember } from '@coongro/staff';
 
 import { usePatientsSettings } from '../hooks/usePatientsSettings.js';
 import { usePet } from '../hooks/usePet.js';
@@ -416,14 +418,16 @@ export function PetForm(props: PetFormProps) {
             false,
             '+54 11 9999-0000'
           ),
-          renderField(
-            'Veterinario preferido',
-            'preferred_vet',
-            'text',
-            vetData,
-            handleVetChange,
-            false,
-            'Dr. García'
+          React.createElement(
+            'div',
+            { className: FIELD_CLASS },
+            renderLabel('Veterinario preferido'),
+            React.createElement(StaffPicker, {
+              value: (vetData.preferred_vet_staff_id as string | null) ?? null,
+              onChange: (member: StaffMember | null) =>
+                handleVetChange('preferred_vet_staff_id', member?.id ?? null),
+              placeholder: 'Buscar veterinario...',
+            })
           ),
           React.createElement(
             'div',

--- a/src/repositories/vet-owner.repository.ts
+++ b/src/repositories/vet-owner.repository.ts
@@ -76,7 +76,6 @@ export class VetOwnerRepository {
       if (query) {
         const pattern = `%${query}%`;
         const searchCond = or(
-          ilike(vetOwnerTable.preferred_vet, pattern),
           ilike(vetOwnerTable.emergency_phone, pattern),
           ilike(vetOwnerTable.notes, pattern)
         );

--- a/src/schema/vet-owner.ts
+++ b/src/schema/vet-owner.ts
@@ -4,7 +4,7 @@ import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 export const vetOwnerTable = pgTable('module_patients_vet_owners', {
   id: uuid('id').primaryKey().notNull(),
   contact_id: text('contact_id').notNull(),
-  preferred_vet: text('preferred_vet'),
+  preferred_vet_staff_id: text('preferred_vet_staff_id'),
   emergency_phone: text('emergency_phone'),
   referral_source: text('referral_source'),
   notes: text('notes'),

--- a/src/types/vet-owner.ts
+++ b/src/types/vet-owner.ts
@@ -7,7 +7,7 @@ export type ReferralSource = 'referral' | 'google' | 'social' | 'walk_in' | 'oth
 export interface VetOwner {
   id: string;
   contact_id: string;
-  preferred_vet: string | null;
+  preferred_vet_staff_id: string | null;
   emergency_phone: string | null;
   referral_source: string | null;
   notes: string | null;
@@ -18,7 +18,7 @@ export interface VetOwner {
 export interface VetOwnerCreateData {
   id?: string;
   contact_id: string;
-  preferred_vet?: string | null;
+  preferred_vet_staff_id?: string | null;
   emergency_phone?: string | null;
   referral_source?: string | null;
   notes?: string | null;

--- a/src/views/owner-detail/index.tsx
+++ b/src/views/owner-detail/index.tsx
@@ -4,6 +4,7 @@
 import { ContactDetail, ContactForm } from '@coongro/contacts';
 import type { Contact } from '@coongro/contacts';
 import { getHostReact, getHostUI, usePlugin } from '@coongro/plugin-sdk';
+import { StaffBadge } from '@coongro/staff';
 
 import { PetCard } from '../../components/PetCard.js';
 import { PetForm } from '../../components/PetForm.js';
@@ -80,7 +81,20 @@ export function OwnerDetailView(props: { contactId?: string }) {
               'div',
               { className: 'grid grid-cols-2 gap-3' },
               vetOwner.emergency_phone && renderField('Tel. emergencia', vetOwner.emergency_phone),
-              vetOwner.preferred_vet && renderField('Vet preferido', vetOwner.preferred_vet),
+              vetOwner.preferred_vet_staff_id &&
+                React.createElement(
+                  'div',
+                  { className: 'flex flex-col gap-0.5' },
+                  React.createElement(
+                    'span',
+                    { className: 'text-xs text-cg-text-muted' },
+                    'Vet preferido'
+                  ),
+                  React.createElement(StaffBadge, {
+                    staffId: vetOwner.preferred_vet_staff_id,
+                    variant: 'compact',
+                  })
+                ),
               vetOwner.referral_source &&
                 renderField('Llegó por', formatReferral(vetOwner.referral_source)),
               vetOwner.notes && renderField('Notas vet', vetOwner.notes)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,9 @@
       ],
       "@coongro/contacts/*": [
         "../contacts/dist/*"
+      ],
+      "@coongro/staff": [
+        "../staff/dist/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Work item: COONG-90

## Summary
Migrate `preferred_vet` (free-text input) to `preferred_vet_staff_id` using `StaffPicker` + `StaffBadge` from `@coongro/staff`. Consistent with the `consultations.vet_name → staff_id` migration (COONG-82).

## Changes
- `schema/vet-owner.ts`: `preferred_vet` → `preferred_vet_staff_id`
- `types/vet-owner.ts`: rename in `VetOwner` and `VetOwnerCreateData`
- `components/PetForm.tsx`: replace free-text `renderField` with `StaffPicker`
- `components/PetDetail.tsx`: render with `StaffBadge` (compact)
- `views/owner-detail/index.tsx`: idem
- `repositories/vet-owner.repository.ts`: remove `ilike` on `preferred_vet` from search
- `package.json` + `tsconfig.json`: add `@coongro/staff` dep + path mapping
- `drizzle/0001_migrate_preferred_vet_to_staff_id.sql` (DROP + ADD)
- `drizzle/meta/0001_snapshot.json` (hand-generated — see note below)

Note: existing `preferred_vet` text data is lost by the migration (kit in development, no production data).

## Testing
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm run quality` passes (lint warnings are pre-existing, out of scope)
- [ ] Runtime: create a new pet → `StaffPicker` appears in "Veterinario preferido" (only staff with vet role)
- [ ] Runtime: pet detail + owner detail render `StaffBadge` correctly

## Notes for reviewer
- The `drizzle/meta/0001_snapshot.json` was generated by hand (drizzle-kit generate requires TTY for the "create or rename column?" prompt). Low risk, but if someone runs `db:generate` afterward, drizzle may detect drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)