### PR TITLE
feat(species): exporta taxonomía de especies como fuente única (COONG-225 #9)

### DIFF
--- a/.changeset/coong-225-species-master.md
+++ b/.changeset/coong-225-species-master.md
@@ -1,0 +1,15 @@
+---
+'@coongro/patients': minor
+---
+
+feat(COONG-225 #9): exporta la taxonomía de especies como fuente única
+
+Pacientes es el dueño de la taxonomía de especies, pero vet-pharmacy y vaccination
+la duplicaban (lista de especies, labels/iconos y el normalizador de texto SENASA).
+Ahora se exporta todo desde `@coongro/patients` para consumir sin copiar:
+
+- `SPECIES` (array `{code,label,icon}`) + tipo `SpeciesDef` — fuente única; los
+  maps `SPECIES_LABELS`/`SPECIES_ICON` se derivan de ahí.
+- `SPECIES_ENABLED_DEFAULT` — defaults de especies habilitadas.
+- `speciesCodeFromText(raw)` — normaliza texto libre/SENASA (canino, felino, ganado…)
+  al código interno; reemplaza el `senasaSpeciesToCode` duplicado en otros plugins.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-  schema: ['./src/schema/pet.ts', './src/schema/vet-owner.ts'],
+  // Auto-discovery de schemas: todos los .ts de src/schema/ menos el barrel index.
+  // Evita tener que registrar a mano cada tabla nueva en este array (COONG-225 #11).
+  schema: './src/schema/!(index).ts',
   out: './drizzle',
   dialect: 'postgresql',
   verbose: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,10 +81,14 @@ export {
   formatSex,
   formatReproductive,
   formatReferral,
+  SPECIES,
   SPECIES_LABELS,
+  SPECIES_ENABLED_DEFAULT,
+  speciesCodeFromText,
   STATUS_LABELS,
   SEX_LABELS,
   REPRODUCTIVE_LABELS,
   REFERRAL_LABELS,
   SPECIES_ICON,
 } from './utils/labels.js';
+export type { SpeciesDef } from './utils/labels.js';

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -2,14 +2,60 @@
  * Labels de dominio para la UI.
  */
 
-export const SPECIES_LABELS: Record<string, string> = {
-  dog: 'Perro',
-  cat: 'Gato',
-  bird: 'Ave',
-  reptile: 'Reptil',
-  rodent: 'Roedor',
-  other: 'Otro',
+/**
+ * Taxonomía de especies — **fuente única** del sistema (COONG-225 #9).
+ *
+ * Pacientes es el dueño de la taxonomía; vet-pharmacy y vaccination la duplicaban
+ * (lista + normalizador). Ahora la importan de `@coongro/patients`. Los maps de
+ * label/icon se DERIVAN de acá para que no haya copias que se desincronicen.
+ */
+export interface SpeciesDef {
+  /** Código interno persistido (dog, cat, …). */
+  code: string;
+  /** Etiqueta en español. */
+  label: string;
+  /** Nombre de icono Lucide. */
+  icon: string;
+}
+
+export const SPECIES: readonly SpeciesDef[] = [
+  { code: 'dog', label: 'Perro', icon: 'Dog' },
+  { code: 'cat', label: 'Gato', icon: 'Cat' },
+  { code: 'bird', label: 'Ave', icon: 'Bird' },
+  { code: 'reptile', label: 'Reptil', icon: 'Turtle' },
+  { code: 'rodent', label: 'Roedor', icon: 'Rabbit' },
+  { code: 'other', label: 'Otro', icon: 'PawPrint' },
+];
+
+export const SPECIES_LABELS: Record<string, string> = Object.fromEntries(
+  SPECIES.map((s) => [s.code, s.label])
+);
+
+/** Defaults de especies habilitadas (alineado con el manifest de settings). */
+export const SPECIES_ENABLED_DEFAULT: Record<string, boolean> = {
+  dog: true,
+  cat: true,
+  bird: false,
+  reptile: false,
+  rodent: false,
+  other: true,
 };
+
+/**
+ * Normaliza un texto libre de especie (taxonomía SENASA en mayúscula/plural,
+ * "canino"/"felino"/ganado, etc.) al código interno de Pacientes. El ganado
+ * (bovino/equino/porcino/ovino) no tiene equivalente de mascota → 'other'.
+ * Reemplaza el `senasaSpeciesToCode` que vet-pharmacy y vaccination duplicaban.
+ */
+export function speciesCodeFromText(raw: string): string {
+  const t = raw.toLowerCase();
+  if (t.includes('canino') || t.includes('perro')) return 'dog';
+  if (t.includes('felino') || t.includes('gato')) return 'cat';
+  if (t.includes('ave') || t.includes('avi')) return 'bird';
+  if (t.includes('reptil')) return 'reptile';
+  if (t.includes('roedor')) return 'rodent';
+  return 'other';
+}
 
 export const STATUS_LABELS: Record<string, string> = {
   active: 'Activo',
@@ -38,15 +84,10 @@ export const REFERRAL_LABELS: Record<string, string> = {
   other: 'Otro',
 };
 
-/** Mapeo especie → nombre de icono Lucide (coherente con manifest settings) */
-export const SPECIES_ICON: Record<string, string> = {
-  dog: 'Dog',
-  cat: 'Cat',
-  bird: 'Bird',
-  reptile: 'Turtle',
-  rodent: 'Rabbit',
-  other: 'PawPrint',
-};
+/** Mapeo especie → nombre de icono Lucide. Derivado de SPECIES (fuente única). */
+export const SPECIES_ICON: Record<string, string> = Object.fromEntries(
+  SPECIES.map((s) => [s.code, s.icon])
+);
 
 /** Convierte un mapa de labels a opciones para Select */
 export function toSelectOptions(


### PR DESCRIPTION
Parte de **COONG-225 #9** (master-data compartida). Pacientes es el dueño de la taxonomía de especies; vet-pharmacy y vaccination la duplicaban. Este PR la expone como fuente única.

## Cambios
- `SPECIES` (array `{code,label,icon}`) + tipo `SpeciesDef` — fuente única; `SPECIES_LABELS`/`SPECIES_ICON` ahora se DERIVAN de ahí.
- `SPECIES_ENABLED_DEFAULT` — defaults de especies habilitadas.
- `speciesCodeFromText(raw)` — normaliza texto libre/SENASA (canino/felino/ganado…) al código interno; reemplaza el `senasaSpeciesToCode` duplicado.

## Verificación
- typecheck + build de patients ✅
- Consumido en vivo por vet-pharmacy (chips de ESPECIES en Medicamentos correctos) ✅

⚠️ **Mergear y publicar ANTES** que los PRs consumidores (vet-pharmacy / vaccination #9). Changeset minor incluido.